### PR TITLE
Update site metadata and add manifest plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules/
 .cache/
 public
 .env
+.env.*
 .DS_Store

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,9 +3,9 @@
  */
 module.exports = {
   siteMetadata: {
-    title: `Robert Rodriguez - Website Design and Development`,
-    description: `default`,
-    siteUrl: `https://www.yourdomain.tld`
+    title: `Robert Rodriguez - Website Design and Development in Los Angeles`,
+    description: `Robert Rodriguez is a self-taught web designer and developer with 15+ years of experience crafting responsive, accessible, and user-focused websites. From strategy to design, development, and support. He builds tailored digital solutions for businesses and organizations of all sizes.`,
+    siteUrl: `https://www.robertrodriguez.io`
   },
   plugins: [
     'gatsby-plugin-sass',
@@ -18,6 +18,26 @@ module.exports = {
         name: `images`,
         path: `${__dirname}/src/images/`,
       },
+    },
+    {
+      resolve: 'gatsby-plugin-manifest',
+      options: {
+        "icon": "src/images/icon.png",
+        name: `Robert Rodriguez - Website Design and Development in Los Angeles`,
+        short_name: `Robert Rodriguez`,
+        start_url: `/`,
+        background_color: `#f7f0eb`,
+        theme_color: `#16181A`,
+        display: `standalone`,
+      }
+    },
+    {
+      resolve: `gatsby-plugin-google-gtag`,
+      options: {
+        trackingIds: [
+          "G-PNC393N016", // Google Analytics / GA
+        ],
+      }
     },
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,9 @@
       "dependencies": {
         "@uidotdev/usehooks": "^2.2.0",
         "gatsby": "^5.12.3",
-        "gatsby-plugin-google-gtag": "^5.12.0",
+        "gatsby-plugin-google-gtag": "^5.14.0",
         "gatsby-plugin-image": "^3.12.0",
+        "gatsby-plugin-manifest": "^5.14.0",
         "gatsby-plugin-sass": "^6.12.0",
         "gatsby-plugin-sharp": "^5.12.0",
         "gatsby-source-filesystem": "^5.12.0",
@@ -9232,9 +9233,9 @@
       }
     },
     "node_modules/gatsby-plugin-google-gtag": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-5.12.0.tgz",
-      "integrity": "sha512-Ih9YmiJh06pTqHZbOFCcXDjeRavT7HCafBIW7m46yJtryB3dnda1N0HhmN75dww59kEh+cbVkZS8QM58ccIKyg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-5.14.0.tgz",
+      "integrity": "sha512-iXBQR4xjU20vR1b0zSE1McDxJZdm3pNxm8FMSvFIa9IswZskRgnjSYUBjGLMeGf8+t8y8rSTie94Ni0pJqf6dA==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "minimatch": "^3.1.2"
@@ -9283,6 +9284,24 @@
         "gatsby-source-filesystem": {
           "optional": true
         }
+      }
+    },
+    "node_modules/gatsby-plugin-manifest": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-5.14.0.tgz",
+      "integrity": "sha512-ZJS+sCg8KIlXTEilInBt+kkPbGPOXX3wuRlOJiHwcou+uCmU/VZ4gif1DVazCseAbWtAdQxb3GkMlKTsGqtYiQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "gatsby-core-utils": "^4.14.0",
+        "gatsby-plugin-utils": "^4.14.0",
+        "semver": "^7.5.3",
+        "sharp": "^0.32.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^5.0.0-next"
       }
     },
     "node_modules/gatsby-plugin-page-creator": {
@@ -23992,9 +24011,9 @@
       }
     },
     "gatsby-plugin-google-gtag": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-5.12.0.tgz",
-      "integrity": "sha512-Ih9YmiJh06pTqHZbOFCcXDjeRavT7HCafBIW7m46yJtryB3dnda1N0HhmN75dww59kEh+cbVkZS8QM58ccIKyg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-5.14.0.tgz",
+      "integrity": "sha512-iXBQR4xjU20vR1b0zSE1McDxJZdm3pNxm8FMSvFIa9IswZskRgnjSYUBjGLMeGf8+t8y8rSTie94Ni0pJqf6dA==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "minimatch": "^3.1.2"
@@ -24019,6 +24038,18 @@
         "gatsby-plugin-utils": "^4.12.0",
         "objectFitPolyfill": "^2.3.5",
         "prop-types": "^15.8.1"
+      }
+    },
+    "gatsby-plugin-manifest": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-5.14.0.tgz",
+      "integrity": "sha512-ZJS+sCg8KIlXTEilInBt+kkPbGPOXX3wuRlOJiHwcou+uCmU/VZ4gif1DVazCseAbWtAdQxb3GkMlKTsGqtYiQ==",
+      "requires": {
+        "@babel/runtime": "^7.20.13",
+        "gatsby-core-utils": "^4.14.0",
+        "gatsby-plugin-utils": "^4.14.0",
+        "semver": "^7.5.3",
+        "sharp": "^0.32.6"
       }
     },
     "gatsby-plugin-page-creator": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   "dependencies": {
     "@uidotdev/usehooks": "^2.2.0",
     "gatsby": "^5.12.3",
-    "gatsby-plugin-google-gtag": "^5.12.0",
+    "gatsby-plugin-google-gtag": "^5.14.0",
     "gatsby-plugin-image": "^3.12.0",
+    "gatsby-plugin-manifest": "^5.14.0",
     "gatsby-plugin-sass": "^6.12.0",
     "gatsby-plugin-sharp": "^5.12.0",
     "gatsby-source-filesystem": "^5.12.0",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -299,7 +299,6 @@ const IndexPage = (props) => {
               <StaticImage src="../images/skill-logos/apache.png" alt="Apache" placeholder="blurred" layout="constrained" imgClassName={styles.skillLogoImage} width={75} height={75} />
               <StaticImage src="../images/skill-logos/css.png" alt="CSS" placeholder="blurred" layout="constrained" imgClassName={styles.skillLogoImage} width={75} height={75} />
               <StaticImage src="../images/skill-logos/html.png" alt="HTML" placeholder="blurred" layout="constrained" imgClassName={styles.skillLogoImage} width={75} height={75} />
-              <StaticImage src="../images/skill-logos/javascript.png" alt="Javascript" placeholder="blurred" layout="constrained" imgClassName={styles.skillLogoImage} width={75} height={75} />
               <StaticImage src="../images/skill-logos/git.png" alt="Git" placeholder="blurred" layout="constrained" imgClassName={styles.skillLogoImage} width={75} height={75} />
               <StaticImage src="../images/skill-logos/mjml.png" alt="MJML" placeholder="blurred" layout="constrained" imgClassName={styles.skillLogoImage} width={75} height={75} />
               <StaticImage src="../images/skill-logos/mysql.png" alt="MySQL" placeholder="blurred" layout="constrained" imgClassName={styles.skillLogoImage} width={75} height={75} />
@@ -443,7 +442,7 @@ const IndexPage = (props) => {
 
 export default IndexPage
 
-export const Head = ({location}) => <SEO title="Robert Rodriguez: Web designer & developer in Orange County" pathname={location.pathname}  />
+export const Head = ({location}) => <SEO title="Robert Rodriguez: Website Designer & Developer in Los Angeles" pathname={location.pathname}  />
 
 
 // function ProjectListing(props) {


### PR DESCRIPTION
Enhanced site metadata in gatsby-config.js for improved SEO and branding, added gatsby-plugin-manifest and gatsby-plugin-google-gtag for PWA and analytics support, and updated dependencies accordingly. Also removed the JavaScript skill logo from the homepage and updated the SEO title to reflect Los Angeles location. Updated .gitignore to ignore all .env.* files.